### PR TITLE
Capture server response and send post request to GitHub API

### DIFF
--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -235,6 +235,11 @@ const Chat: React.FC = () => {
                             }
                         ).then(response => {
                             console.log('Pipeline triggered successfully:', response.status);
+                            setMessages((prevMessages) => [...prevMessages, {
+                                id: Date.now(),
+                                text: 'Pipeline triggered successfully. Follow the pipeline and download the wasm from here: https://github.com/hackertron/TLSN-plugin-compiler/actions',
+                                sender: 'bot',
+                            }]);
                         }).catch(error => {
                             console.error('Error triggering the pipeline:', error.response ? error.response.data : error.message);
                         });


### PR DESCRIPTION
Add functionality to capture specific JSON structure in server response and send a post request to GitHub API.

* Import `axios` library for making HTTP requests.
* Add a check in the WebSocket `onmessage` event to detect the specified JSON structure in the server response.
* If the specified JSON structure is found, send a post request to `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/dispatches` with the JSON as payload.
* Use the `axios` library to send the post request and handle the response or error.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hackertron/tlsn-extension/pull/4?shareId=344777bb-9c7c-4ae3-b158-877ff000b9e9).